### PR TITLE
Engine::flushStep: fix segmentation fault of timer

### DIFF
--- a/src_cpp/yaafe-core/Engine.cpp
+++ b/src_cpp/yaafe-core/Engine.cpp
@@ -336,19 +336,22 @@ namespace YAAFE {
   }
 
   inline bool Engine::flushStep(ProcessFlow::Node& step) {
+    if (step.v.m_component!=NULL) {
 #ifdef DEBUG
-    if (verboseFlag)
-      cerr << "flush step " << step.v.m_component->getIdentifier() << endl;
+      if (verboseFlag) {
+        cerr << "flush step " << step.v.m_component->getIdentifier() << endl;
+      }
 #endif
+
 #ifdef WITH_TIMERS
-    Timer* t = Timer::get_timer(step.v.m_component->getIdentifier());
-    t->start();
-#endif
-    if (step.v.m_component!=NULL)
+      Timer* t = Timer::get_timer(step.v.m_component->getIdentifier());
+      t->start();
       step.v.m_component->flush(step.v.m_input, step.v.m_output);
-#ifdef WITH_TIMERS
-    t->stop();
+      t->stop();
+#else
+      step.v.m_component->flush(step.v.m_input, step.v.m_output);
 #endif
+    }
     for (int i=0;i<step.v.m_output.size();i++)
       step.v.m_output[i].data->flush();
     return true;


### PR DESCRIPTION
if built with `WITH_TIMER ON`, `python examples/frames.py ./resources/yaafe_check.wav` will fail with a segmentation fault, but `yaafe-engine -c ./resources/yaflow32k ./resources/yaafe_check.wav` works fine.

I wonder if `Engine::flushStep()` is called `N+1` times in python module, while in pure C++ implemention(yaafe-engine), it is called only `N` times if loaded the same dataflow, and the last time is blame for writer like `CSVWriter`. As yaafe-engine would write some csv files but a python script doesn't.
