### PR TITLE
Limit max frequency of Mel filterbank to Nyquist frequency

### DIFF
--- a/src_cpp/yaafe-components/audio/MelFilterBank.cpp
+++ b/src_cpp/yaafe-components/audio/MelFilterBank.cpp
@@ -73,6 +73,8 @@ namespace YAAFE
     double sampleRate = in.sampleRate;
     double freqMin = getDoubleParam("MelMinFreq",params);
     double freqMax = getDoubleParam("MelMaxFreq",params);
+    // set freqMax to Nyquist frequency if greater than nyquist frequency
+    freqMax = min(freqMax, sampleRate/2.0);
     double melFreqMin = 1127 * log(1 + freqMin / 700);
     double melFreqMax = 1127 * log(1 + freqMax / 700);
 


### PR DESCRIPTION
Set max frequency of Mel filter bank to Nyquist frequency if greater than Nyquist frequency. Avoid troubles (incoherent values in high frequencies for MelSpectrum, MFCC) when Nyquist frequency is lower than maximum mel filterbank frequency. This kind of troubles typically occurs when computing MelSpectrum or MFCC with default parameters (MelMaxFreq = 6854.0) on a signal with sample rate 11025Hz (Nyquist frequency = 5512.5Hz).