### PR TITLE
Windows native compilation, minor fixes

### DIFF
--- a/INSTALL_WINDOWS
+++ b/INSTALL_WINDOWS
@@ -53,3 +53,6 @@ Windows Native Compilation
 Native compilation under windows should be very similar to the description above, if you use the MingW compiler (gcc):
 http://www.mingw.org/
 
+A thorough tutorial is given in the following blogpost:
+https://crococode.wordpress.com/2015/04/01/compiling-yaafe-on-windows-using-cmake-and-mingw/
+Feel free to contact!

--- a/src_cpp/yaafe-core/DataFlow.cpp
+++ b/src_cpp/yaafe-core/DataFlow.cpp
@@ -210,7 +210,7 @@ namespace YAAFE
   bool DataFlow::loads(const std::string& df_str)
   {
     // fmemopen  http://www.delorie.com/gnu/docs/glibc/libc_228.html
-    #ifdef APPLE
+    #ifdef __APPLE__
     const char* buf = df_str.c_str();
     size_t buf_size = sizeof(char) * (df_str.size() + 1);
     FILE* yyin = fmemopen((void *)buf, buf_size, "r");

--- a/src_cpp/yaafe-core/DataFlow.cpp
+++ b/src_cpp/yaafe-core/DataFlow.cpp
@@ -210,6 +210,7 @@ namespace YAAFE
   bool DataFlow::loads(const std::string& df_str)
   {
     // fmemopen  http://www.delorie.com/gnu/docs/glibc/libc_228.html
+    #ifdef APPLE
     const char* buf = df_str.c_str();
     size_t buf_size = sizeof(char) * (df_str.size() + 1);
     FILE* yyin = fmemopen((void *)buf, buf_size, "r");
@@ -217,7 +218,9 @@ namespace YAAFE
       cerr << "cannot parse dataflow:" << endl << df_str << endl;
       return false;
     }
+
     return yyparse(yyin);
+    #endif
   }
 
   bool DataFlow::yyparse(FILE* yyin)

--- a/src_cpp/yaafe-core/DataFlow.cpp
+++ b/src_cpp/yaafe-core/DataFlow.cpp
@@ -210,7 +210,7 @@ namespace YAAFE
   bool DataFlow::loads(const std::string& df_str)
   {
     // fmemopen  http://www.delorie.com/gnu/docs/glibc/libc_228.html
-    #ifndef _WIN32
+    #ifndef __WIN32
     const char* buf = df_str.c_str();
     size_t buf_size = sizeof(char) * (df_str.size() + 1);
     FILE* yyin = fmemopen((void *)buf, buf_size, "r");

--- a/src_cpp/yaafe-core/DataFlow.cpp
+++ b/src_cpp/yaafe-core/DataFlow.cpp
@@ -210,7 +210,7 @@ namespace YAAFE
   bool DataFlow::loads(const std::string& df_str)
   {
     // fmemopen  http://www.delorie.com/gnu/docs/glibc/libc_228.html
-    #ifdef __APPLE__
+    #ifndef _WIN32
     const char* buf = df_str.c_str();
     size_t buf_size = sizeof(char) * (df_str.size() + 1);
     FILE* yyin = fmemopen((void *)buf, buf_size, "r");

--- a/src_cpp/yaafe-core/OutputFormat.cpp
+++ b/src_cpp/yaafe-core/OutputFormat.cpp
@@ -88,6 +88,19 @@ namespace YAAFE {
   std::string OutputFormat::filenameConcat(const std::string& outDir,
       const std::string& filename, const std::string& suffix)
   {
+   #ifdef __WIN32
+      string outfile = "";
+      if (outDir.size()==0)
+        outfile = filename;
+      else{
+        if (outDir[outDir.size()-1]!='\\')
+            outfile = outDir + filename.substr(2);
+        else
+            outfile = outDir + filename.substr(3);
+      }
+      return outfile + suffix;
+
+   #else
     string outfile = "";
     if (filename[0]=='/') {
       if (outDir.size()==0)
@@ -105,6 +118,7 @@ namespace YAAFE {
         outfile = outDir + filename;
     }
     return outfile + suffix;
+    #endif
   }
 
   void OutputFormat::eraseParameterDescriptor(ParameterDescriptorList& list,

--- a/src_cpp/yaafe-io/io/FileUtils.cpp
+++ b/src_cpp/yaafe-io/io/FileUtils.cpp
@@ -30,6 +30,7 @@
 // define for path delimiter
 #ifdef __WIN32
  #define YAAFE_PATH_DELIMITER "\\"
+ #include <windows.h>
 #else
  #define YAAFE_PATH_DELIMITER "/"
 #endif
@@ -58,7 +59,7 @@ namespace YAAFE
 	  }
 	// create dir
 #ifdef __WIN32
-        int res = mkdir(path.c_str());
+        int res = CreateDirectory(path.c_str(),NULL);
 #else
         int res = mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 #endif

--- a/src_python/yaafelib/core.py
+++ b/src_python/yaafelib/core.py
@@ -30,7 +30,7 @@ import sys
 
 # load C library
 if sys.platform.startswith("win32"):
-    yaafecore = cdll.LoadLibrary('libyaafecore.dll')
+    yaafecore = cdll.LoadLibrary('libyaafe-python.dll')
 else:
     yaafecore = cdll.LoadLibrary('libyaafe-python.so')
 


### PR DESCRIPTION
I compiled Yaafe on a Windows system using CMake and MinGW. I fixed some minor runtime and compilation issues along the way and documented everything in a tutorial:
https://crococode.wordpress.com/2015/04/01/compiling-yaafe-on-windows-using-cmake-and-mingw/