### PR TITLE
Replace StopIteration exceptions with "return" for PEP 479

### DIFF
--- a/src_python/yaafelib/core.py
+++ b/src_python/yaafelib/core.py
@@ -48,14 +48,14 @@ def iterPtrList(plist):
     """ usefull function """
     for i in count(0):
         if not plist[i]:
-            raise StopIteration
+            return
         yield plist[i]
 
 
 def iterPtrDict(plist):
     for i in count(0):
         if not plist[i][0]:
-            raise StopIteration
+            return
         yield plist[i][0], plist[i][1]
 
 


### PR DESCRIPTION
This is needed for Python 3.7 compatibility.

There are various similar issues faced by [other projects](https://github.com/googleapis/google-cloud-python/issues/5282).

[PEP 479](https://www.python.org/dev/peps/pep-0479/#writing-backwards-and-forwards-compatible-code) proposes a simple solution: "If `raise StopIteration` occurs directly in a generator, simply replace it with `return`."