### PR TITLE
change env python for #52

### DIFF
--- a/src_python/yaafelib/yaafe.py
+++ b/src_python/yaafelib/yaafe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: ISO-8859-1 -*-
 #
 # Yaafe


### PR DESCRIPTION
debian jessie env has no python3 to use, so this small fix allows us to use the docker build from source.